### PR TITLE
big speedup to lists

### DIFF
--- a/mGui/bindings.py
+++ b/mGui/bindings.py
@@ -65,9 +65,6 @@ class Accessor(object):
         try:
             self._set(*args, **kwargs)
             return True
-        except MGuiAttributeError:
-            cmds.warning("Slent MGUI fail!")
-            return False
         except:
             if BREAK_ON_ACCESS_FAILURE:
                 raise
@@ -82,9 +79,6 @@ class Accessor(object):
         """
         try:
             return self._get(*args, **kwargs)
-        except MGuiAttributeError:
-            cmds.warning("Slent MGUI fail!")
-            return 0
         except:
             if BREAK_ON_ACCESS_FAILURE:
                 raise

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -186,6 +186,15 @@ class Control(Styled, BindableObject):
         finally:
             cls.CMD = _cmd
 
+    def _extract_kwarg(self, key, kwarg, default = None):
+        '''
+        gets the value for <key> from dictionary <kwarg> and returns it. If the key is present in <kwarg> it will be
+        removed. If a default is supplied it will be returned when the key is not present
+        '''
+        result = kwarg.get(key, default)
+        if key in kwarg:
+            del kwarg[key]
+        return result
 
 class Nested(Control):
     """
@@ -205,7 +214,7 @@ class Nested(Control):
         self.Controls = []
         self.ignore_exceptions = False
         super(Nested, self).__init__(key, *args, **kwargs)
-
+        self.Deleted += self.forget
 
     def __enter__(self):
         self.__cache_layout = Nested.ACTIVE_LAYOUT
@@ -306,6 +315,10 @@ class Nested(Control):
     @classmethod
     def current(cls):
         return Nested.ACTIVE_LAYOUT
+
+    @classmethod
+    def forget(cls, *args, **kwargs):
+        Nested.ACTIVE_LAYOUT.remove(kwargs['sender'])
 
 # IMPORTANT NOTE
 # this intentionally duplicates redundant property names from Control.

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -100,9 +100,7 @@ class Control(Styled, BindableObject):
 
     def __init__(self, key, *args, **kwargs):
         # arbitrary tag data. Use with care to avoid memory leaks
-        self.Tag = kwargs.get('tag', None)
-        if 'tag' in kwargs:
-            del kwargs['tag']
+        self.Tag = self._extract_kwarg('tag', kwargs)
 
         # this applies any keywords in the current style that are part of the Maya gui flags
         # other flags (like float and margin) are ignored
@@ -195,6 +193,7 @@ class Control(Styled, BindableObject):
         if key in kwarg:
             del kwarg[key]
         return result
+
 
 class Nested(Control):
     """
@@ -318,7 +317,8 @@ class Nested(Control):
 
     @classmethod
     def forget(cls, *args, **kwargs):
-        Nested.ACTIVE_LAYOUT.remove(kwargs['sender'])
+        if Nested.ACTIVE_LAYOUT is not None:
+            Nested.ACTIVE_LAYOUT.remove(kwargs['sender'])
 
 # IMPORTANT NOTE
 # this intentionally duplicates redundant property names from Control.
@@ -369,7 +369,8 @@ class Window(Nested):
 
     @classmethod
     def forget(cls, *args, **kwargs):
-        Window.ACTIVE_WINDOWS.remove(kwargs['sender'])
+        if Window.ACTIVE_WINDOWS is not None:
+            Window.ACTIVE_WINDOWS.remove(kwargs['sender'])
 
     def show(self):
         cmds.showWindow(self.Widget)
@@ -382,6 +383,7 @@ class Window(Nested):
         if Window.ACTIVE_WINDOWS:
             return Window.ACTIVE_WINDOWS[-1]
         return None
+
 
 
 class BindingWindow(Window):

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -318,7 +318,9 @@ class Nested(Control):
     @classmethod
     def forget(cls, *args, **kwargs):
         if Nested.ACTIVE_LAYOUT is not None:
-            Nested.ACTIVE_LAYOUT.remove(kwargs['sender'])
+            sender = kwargs.get('sender', None)
+            if sender in Nested.ACTIVE_LAYOUT:
+               Nested.ACTIVE_LAYOUT.remove(sender)
 
 # IMPORTANT NOTE
 # this intentionally duplicates redundant property names from Control.
@@ -370,7 +372,9 @@ class Window(Nested):
     @classmethod
     def forget(cls, *args, **kwargs):
         if Window.ACTIVE_WINDOWS is not None:
-            Window.ACTIVE_WINDOWS.remove(kwargs['sender'])
+            sender = kwargs.get('sender', None)
+            if sender in Nested.ACTIVE_LAYOUT:
+               Nested.ACTIVE_LAYOUT.remove(sender)
 
     def show(self):
         cmds.showWindow(self.Widget)

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -308,7 +308,7 @@ class Nested(Control):
 
     @classmethod
     def add_current(cls, control):
-        if Nested.ACTIVE_LAYOUT:
+        if Nested.ACTIVE_LAYOUT is not None:
             Nested.ACTIVE_LAYOUT.add(control)
 
     @classmethod

--- a/mGui/events.py
+++ b/mGui/events.py
@@ -122,6 +122,7 @@ class Event(object):
         """
         return len([i for i in self._Handlers])
 
+
     # hook up the instance methods to the base methods
     # doing it this way allows you to override more neatly
     # in derived classes
@@ -129,6 +130,8 @@ class Event(object):
     __len__ = _handlerCount
     __iadd__ = _addHandler
     __isub__ = _removeHandler
+
+
 
 
 class MayaEvent(Event):

--- a/mGui/examples/boundCollection.py
+++ b/mGui/examples/boundCollection.py
@@ -43,17 +43,22 @@ Key points:
 
 class ExampleTemplate(lists.ItemTemplate):
     def widget(self, item):
-        with forms.HorizontalExpandForm('tmp_%i' % id(item), parent=self.Parent, width=250,) as root:
+        with forms.HorizontalExpandForm('tmp_%i' % id(item),  width=250,) as root:
                 gui.IconTextButton('delete', style='iconAndTextHorizontal', image='delete', tag=item)
                 with forms.VerticalForm('names'):
                     gui.NameField(None, object=item, width=250)
                 with forms.VerticalForm('xform'):
                     gui.AttrFieldGrp('t', label='translate', attribute=item + ".t")
-
         return lists.Templated(item, root, request_delete=root.delete.command)
 
 
 class BoundCollectionWindow(object):
+
+    KEEPALIVE = None
+    # this is handy for the example, you don't want to do it this way
+    # if you really need multiple windows: the single Keepalive will
+    # only support the latest one at a time...
+
     def __init__(self, collection):
 
         # this is the collection of stuff to manage
@@ -77,6 +82,8 @@ class BoundCollectionWindow(object):
 
         self.window.main.itemList.NewWidget += self.hook_widget_events
         flt.filtertext.enterCommand += self.update_filter
+        self.KEEPALIVE = self
+
 
     def update_filter(self, *args, **kwargs):
         sender = kwargs['sender']
@@ -93,6 +100,7 @@ class BoundCollectionWindow(object):
         cmds.delete(kwargs['sender'].Tag)
 
     def hook_widget_events(self, *args, **kwargs):
+        print "I HOOKED", args, kwargs
         kwargs['item'].Events['request_delete'] += self.do_delete
 
     def show(self):

--- a/mGui/lists.py
+++ b/mGui/lists.py
@@ -30,7 +30,7 @@ class FormList(object):
     layout() method when the collection changes, and will prune the layouts
     control sets as items are added to or removed from the bound collection.
     """
-    SCROLL_WIDTH = 25
+    SCROLL_WIDTH = 33
 
     def __init_bound_collection__(self, kwargs):
         """
@@ -67,39 +67,55 @@ class FormList(object):
         return result
 
     def redraw(self, *args, **kwargs):
-        '''
+        """
         NOTE: depends on the LIST_CLASS being set in the actual class!
-        '''
+        """
 
-        if self._scroll != 'not initialized':
-            cmds.deleteUI(self._scroll)
-            self._scroll = 'not initialized'
-            self._list = 'not initialized'
+        try:
+            cmds.waitCursor(st=1)
+            if self._scroll != 'not initialized':
+                cmds.deleteUI(self._scroll)
+                self._scroll = 'not initialized'
+                self._list = 'not initialized'
 
-        cmds.setParent(self)
-        with layouts.ScrollLayout('_scroll', childResizable=True) as self._scroll:
-            with self.LIST_CLASS('_list', **self.Redraw_Opts) as self._list:
-                for item in self.Collection:
-                    w = self.Template.widget(item)
-                    self.widget_added(w)
-        cmds.setParent(self.parent)
+            cmds.setParent(self)
+            with layouts.ScrollLayout('_scroll', childResizable=True) as self._scroll:
+                with self.LIST_CLASS('_list', **self.Redraw_Opts) as self._list:
+                    for item in self.Collection:
+                        w = self.Template.widget(item)
+                        self.widget_added(w)
+            cmds.setParent(self.parent)
 
-        self._scroll.Deleted._handlers = set()
-        self._list.Deleted._handlers = set()
+            # unhook the delete handlers from these guys, they are closed
+            # so they arent part of the ACTIVE_LAYOUT
 
-        self._scroll.Deleted.kill()
-        self._list.Deleted.kill()
+            self._scroll.Deleted._handlers = set()
+            self._list.Deleted._handlers = set()
+            self._scroll.Deleted.kill()
+            self._list.Deleted.kill()
 
-        self.Controls = [self._scroll]
-        self.layout()
+            # remove them so they fall out of scope, but keep the new _scroll
+            self.Controls = [self._scroll]
+            self.layout()
+
+        finally:
+            cmds.waitCursor(st=0)
 
 
     def widget_added(self, templated_item):
-        '''
+        """
         by default, raise the NewWidget event
         but can be overridden to handle here instead
-        '''
+        """
         self.NewWidget(item=templated_item)
+
+    def gui_contents(self):
+        for item in self._list.Controls:
+            yield item
+
+    def contents(self):
+        for item in self.Collection:
+            yield item
 
 
 class VerticalList(forms.FillForm, FormList):
@@ -119,7 +135,7 @@ class VerticalList(forms.FillForm, FormList):
 
     def redraw(self, *args, **kwargs):
         super(VerticalList, self).redraw()
-        self._list.width = max(self.width - 25, 25)
+        self._list.width = max(self.width - 33, 33)
 
 
 class HorizontalList(forms.FillForm, FormList):
@@ -137,7 +153,7 @@ class HorizontalList(forms.FillForm, FormList):
 
     def redraw(self, *args, **kwargs):
         super(HorizontalList, self).redraw()
-        self._list.height = max(self.width - 25, 25)
+        self._list.height = max(self.width - 33, 33)
 
 
 class ColumnList(forms.FillForm, FormList):
@@ -151,7 +167,7 @@ class ColumnList(forms.FillForm, FormList):
 
     def redraw(self, *args, **kwargs):
         super(ColumnList, self).redraw()
-        self._list.width = max(self.width - 25, 25)
+        self._list.width = max(self.width - 33, 33)
 
 
 class WrapList(forms.FillForm, FormList):
@@ -172,8 +188,8 @@ class WrapList(forms.FillForm, FormList):
 
     def redraw(self, *args, **kwargs):
         super(WrapList, self).redraw()
-        self._list.height = max(self.height - 25, 25)
-        self._list.width = max(self.width - 25, 25)
+        self._list.height = max(self.height - 33, 33)
+        self._list.width = max(self.width - 33, 33)
 
 
 class Templated(object):
@@ -183,9 +199,9 @@ class Templated(object):
         self.Events = events
 
     def get_event(self, key):
-        '''
+        """
         Return the named event, if present
-        '''
+        """
         return self.Events.get(key, None)
 
 

--- a/mGui/lists.py
+++ b/mGui/lists.py
@@ -82,6 +82,7 @@ class FormList(object):
                 for item in self.Collection:
                     w = self.Template.widget(item)
                     self.widget_added(w)
+        cmds.setParent(self.parent)
 
         self._scroll.Deleted._handlers = set()
         self._list.Deleted._handlers = set()

--- a/mGui/observable.py
+++ b/mGui/observable.py
@@ -7,6 +7,7 @@ import maya.utils as utils
 from mGui.events import MayaEvent, Event
 from mGui.bindings import BindableObject
 
+
 class ObservableCollection(BindableObject):
     """
     Encapsulates a collection suitable for data binding. The contents are
@@ -120,13 +121,14 @@ class ObservableCollection(BindableObject):
         for item in self._Internal_Collection:
             yield item
 
-class ImmediateObservableCollection(ObservableCollection):
 
+class ImmediateObservableCollection(ObservableCollection):
     def __init__(self, *items):
         self._Internal_Collection = [i for i in items]
         self.CollectionChanged = Event(collection=self)
         self.ItemAdded = Event(collection=self)
         self.ItemRemoved = Event(collection=self)
+
 
 class ViewCollection(ObservableCollection):
     """
@@ -191,7 +193,7 @@ class BoundCollection(BindableObject):
 
     def __init__(self, conversion=lambda x: (x, [])):
         self._Internal_Collection = ()
-        self._Public_Collecton = {}
+        self._Public_Collection = {}
         self.Conversion = conversion
         self.CollectionChanged = MayaEvent()  # these are MayaEvents so they are thread safe... we hope
         self.WidgetCreated = MayaEvent()
@@ -205,10 +207,10 @@ class BoundCollection(BindableObject):
 
         def safe_create_gui():
             for d in deletions:
-                del (self._Public_Collecton[d])
+                del (self._Public_Collection[d])
             for a in additions:
                 templated = self.Conversion(a)
-                self._Public_Collecton[a] = templated.Widget
+                self._Public_Collection[a] = templated.Widget
                 self.WidgetCreated(templated)
 
         utils.executeInMainThreadWithResult(safe_create_gui)
@@ -229,16 +231,17 @@ class BoundCollection(BindableObject):
 
     @property
     def Contents(self):
-        return [self._Public_Collecton[i] for i in self._Internal_Collection]
+        return [self._Public_Collection[i] for i in self._Internal_Collection]
 
     @property
     def Count(self):
         return len(self._Internal_Collection)
 
+
 class ImmediateBoundCollection(BoundCollection):
-     def __init__(self, conversion=lambda x: (x, [])):
+    def __init__(self, conversion=lambda x: (x, [])):
         self._Internal_Collection = ()
-        self._Public_Collecton = {}
+        self._Public_Collection = {}
         self.Conversion = conversion
         self.CollectionChanged = Event()  # these are MayaEvents so they are thread safe... we hope
         self.WidgetCreated = Event()

--- a/mGui/styles.py
+++ b/mGui/styles.py
@@ -122,9 +122,11 @@ class CSS (dict):
     
     def __init__(self, target, *templates, **kwarg):
         super(CSS,self).__init__()
+        inherit = kwarg.get('inherit', True)
 
-        if CSS.ACTIVE:
+        if inherit and CSS.ACTIVE:
             templates = [CSS.ACTIVE] + [i for i in templates]
+
         map(self.update, templates)
         self.update(**kwarg)
         
@@ -203,5 +205,3 @@ class Styled(object):
             del kwargs['css']
                 
         return obj
-   
-                                

--- a/mGui/stylesheets.py
+++ b/mGui/stylesheets.py
@@ -3,7 +3,9 @@ helper functions for creating default CSS sheet
 """
 
 from mGui.styles import CSS, Bounds
-from mGui.core.controls import Labeled, IconTextButton, IconTextCheckBox, IconTextRadioButton, RadioCollection, IconTextRadioCollection
+from mGui.core.controls import *
+from mGui.core.layouts import *
+from mGui.core.menus import *
 from mGui.core import Control
 
 
@@ -32,5 +34,10 @@ def defaults(labels=128, controls=128, label_space=8, field_space=1, margin=(0,)
             CSS(IconTextRadioButton, style='iconAndTextHorizontal')
             CSS(IconTextRadioCollection, inherit=False)
             CSS(RadioCollection,inherit=False)
+            CSS(MenuBarLayout, inherit=False)
+            CSS(Menu, inherit=False)
+            CSS(MenuItem, inherit=False)
+
+
     return defaults
 

--- a/mGui/stylesheets.py
+++ b/mGui/stylesheets.py
@@ -3,32 +3,34 @@ helper functions for creating default CSS sheet
 """
 
 from mGui.styles import CSS, Bounds
-from mGui.core.controls import Labeled, IconTextButton, IconTextCheckBox
+from mGui.core.controls import Labeled, IconTextButton, IconTextCheckBox, IconTextRadioButton, RadioCollection, IconTextRadioCollection
 from mGui.core import Control
 
 
-def defaults(labels=128, controls=128, label_space = 8, field_space = 1, margin = (0,)):
-    m = Bounds(*margin)
-    with CSS(Control, margin=m, width=labels + controls) as defaults:
-        
-        # default style for labeled 'XXXGrp' controls
-        CSS(Labeled, 
-                 columnWidth2=(labels, controls),
-                 columnWidth3=(labels, controls / 2 , controls / 2),
-                 columnWidth4=(labels, controls / 3,  controls / 3, controls / 3),                     
-                 columnAttach2= ['both'] * 2,
-                 columnAttach3=['both'] * 3,
-                 columnAttach4=['both'] * 4,
-                 columnOffset2= [label_space, field_space],
-                 columnOffset3= [label_space] + [field_space] * 2,
-                 columnOffset4=[label_space] + [field_space] * 3,
-                 adjustableColumn = 1,
-                 rowAttach = (1, 'both', field_space))
-    
-        CSS(IconTextButton, style='iconAndTextHorizontal')
-        CSS(IconTextCheckBox, style='iconAndTextHorizontal')
-        
+def defaults(labels=128, controls=128, label_space=8, field_space=1, margin=(0,)):
+    with CSS(Control) as defaults:
+        m = Bounds(*margin)
 
 
+        with CSS(Control, margin=m, width=labels + controls) as defaults:
+            # default style for labeled 'XXXGrp' controls
+            CSS(Labeled,
+                columnWidth2=(labels, controls),
+                columnWidth3=(labels, controls / 2, controls / 2),
+                columnWidth4=(labels, controls / 3, controls / 3, controls / 3),
+                columnAttach2=['both'] * 2,
+                columnAttach3=['both'] * 3,
+                columnAttach4=['both'] * 4,
+                columnOffset2=[label_space, field_space],
+                columnOffset3=[label_space] + [field_space] * 2,
+                columnOffset4=[label_space] + [field_space] * 3,
+                adjustableColumn=1,
+                rowAttach=(1, 'both', field_space))
+
+            CSS(IconTextButton, style='iconAndTextHorizontal')
+            CSS(IconTextCheckBox, style='iconAndTextHorizontal')
+            CSS(IconTextRadioButton, style='iconAndTextHorizontal')
+            CSS(IconTextRadioCollection, inherit=False)
+            CSS(RadioCollection,inherit=False)
     return defaults
 


### PR DESCRIPTION
It turns out that QT is really, really unhappy if you try to reorganize big widgets inside a container. It turns out to way, way faster to simply delete the container and make a new on instead of trying to curate or carefully update a list. 

The 3 main changes:
* boundCollection classes don't create their own widgets anymore, That job belongs to the list classes
* lists now have consist of a fillForm wrapping a scrollLayout wrapping a VerticalForm or HorizontalForm. This seems to be just as fast and is way cleaner
* ItemTemplates don't need to explicitly set their own parents **This is the only change that should affect existing code outside of mgui**