### PR TITLE
Fix for overriding Nest.__exit__

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -205,6 +205,11 @@ class Nested(Control):
     """
     ACTIVE_LAYOUT = None
 
+    def __new__(cls, key=None, **kwargs):
+        inst = super(Nested, cls).__new__(cls, key=None, **kwargs)
+        inst.context_scope = inspect.currentframe().f_back
+        return inst
+
     def __init__(self, key=None, **kwargs):
         self.controls = []
         self.named_children = OrderedDict()
@@ -232,7 +237,7 @@ class Nested(Control):
         # that is closing, add them with variable name as a key
         # this supports a more natural, keyless idiom (see 'add')
 
-        for key, value in inspect.currentframe().f_back.f_locals.items():
+        for key, value in self.context_scope.f_locals.items():
             if value in self:
                 self.add(value, key)
 

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -233,7 +233,7 @@ class Nested(Control):
         # this supports a more natural, keyless idiom (see 'add')
 
         context_scope = inspect.currentframe()
-        for _ in xrange(self._stack_depth()):
+        while context_scope.f_back and self in context_scope.f_back.f_locals.values():
             context_scope = context_scope.f_back
         
         for key, value in context_scope.f_locals.items():
@@ -387,13 +387,6 @@ class Nested(Control):
             self.named_children = {}
         if Nested.ACTIVE_LAYOUT == self:
             Nested.ACTIVE_LAYOUT = None
-
-    @classmethod
-    def _stack_depth(cls):
-        """
-        Used to find exactly how far up the stack we need to go, to find the containing scope.
-        """
-        return len([c for c in cls.mro() if '__exit__' in c.__dict__])
 
 
 # IMPORTANT NOTE


### PR DESCRIPTION
Fixes an issue #28 on classes that override ```Nested.__exit__```.

By moving the call to ```inspect.currentframe().f_back``` into ```Nested.__new__```, we are able to grab the context scope at creation time, but still wait until ```Nested.__exit__``` to actually inspect that scope for any names that we might need to capture.

Granted this just ends up moving issue around, and if any classes override ```Nested.__new__``` we'd be right back where we started.