### PR TITLE
Another fix for overriding Nested.__exit__

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -233,12 +233,11 @@ class Nested(Control):
         # this supports a more natural, keyless idiom (see 'add')
 
         context_scope = inspect.currentframe()
-        while context_scope.f_back and self in context_scope.f_back.f_locals.values():
+        while context_scope.f_back:
             context_scope = context_scope.f_back
-        
-        for key, value in context_scope.f_locals.items():
-            if value in self:
-                self.add(value, key)
+            for key, value in context_scope.f_locals.items():
+                if value in self:
+                    self.add(value, key)
 
         # restore the layout level
         Nested.ACTIVE_LAYOUT = self.__cache_layout


### PR DESCRIPTION
#29 Has an issue where layouts defined as instance fields would no longer get child controls added to them, this should fix that.

Tweaked the stack walking portion. Instead of trying to deduce the  frame where our context is defined, instead we just check all of the frames until we reach the top of the stack.

This does add a lot more checking, but hopefully the results are the same.
This solves an issue when a parent context is defined at the instance level instead of the local level.