### PR TITLE
Changed how the exiting context manager determines the new parent layout

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -245,9 +245,7 @@ class Nested(Control):
         self.layout()
 
         # restore gui parenting
-        abs_parent, sep, _ = self.widget.rpartition("|")
-        if abs_parent:
-            cmds.setParent(abs_parent)
+        cmds.setParent(Nested.ACTIVE_LAYOUT)
 
     def layout(self):
         """
@@ -386,6 +384,13 @@ class Nested(Control):
             self.named_children = {}
         if Nested.ACTIVE_LAYOUT == self:
             Nested.ACTIVE_LAYOUT = None
+
+    def as_parent(self):
+        try:
+            cmds.setParent(self)
+        except RuntimeError as e:
+            cmds.setParent(self, menu=True)
+        return self
 
 
 # IMPORTANT NOTE


### PR DESCRIPTION
Instead of relying on splitting the widgets path, we instead just set the parent to the previous layout that we captured when entering the context.
This fixes some issues when Maya will insert a '||' into the path, specifically when dealing with popup menus, and docked controls.

Also added an as_parent method to Nested instances, this allows you to reuse the object as a parent for more controls.