### PR TITLE
Controls

### DIFF
--- a/mGui/core/controls.py
+++ b/mGui/core/controls.py
@@ -730,8 +730,8 @@ class Text(Control):
 class TextField(Control):
     """Wrapper class for cmds.textField"""
     CMD = cmds.textField
-    _ATTRIBS = ['insertText', 'insertionPosition', 'text', 'editable', 'fileName', 'font']
-    _CALLBACKS = ['alwaysInvokeEnterCommandOnReturn', 'changeCommand', 'enterCommand', 'receiveFocusCommand']
+    _ATTRIBS = ['alwaysInvokeEnterCommandOnReturn', 'insertText', 'insertionPosition', 'text', 'editable', 'fileName', 'font']
+    _CALLBACKS = ['changeCommand', 'enterCommand', 'receiveFocusCommand']
     _BIND_SRC = 'text'
     _BIND_TGT = 'text'
     _BIND_TRIGGER = 'changeCommand'

--- a/mGui/core/controls.py
+++ b/mGui/core/controls.py
@@ -783,7 +783,7 @@ class TextScrollList(Control):
 
     @property
     def items(self):
-        return self.allItems
+        return self.allItems or []
 
     @items.setter
     def items(self, items):

--- a/mGui/helpers/tools.py
+++ b/mGui/helpers/tools.py
@@ -70,6 +70,8 @@ class CommandInfo(object):
         attribs.sort()
         # note this deliberately excludes short names of callbacks!
         callbacks = [c for c in attribs if 'Command' in c or 'Callback' in c] 
+        if 'alwaysInvokeEnterCommandOnReturn' in callbacks: 
+            callbacks.remove('alwaysInvokeEnterCommandOnReturn')
         attribs = list(set(attribs) - set(callbacks))
         quoted = lambda p : "'%s'" % p
         attrib_names = map (quoted, attribs)

--- a/mGui/helpers/tools.py
+++ b/mGui/helpers/tools.py
@@ -69,10 +69,9 @@ class CommandInfo(object):
             
         attribs.sort()
         # note this deliberately excludes short names of callbacks!
-        callbacks = [c for c in attribs if 'Command' in c or 'Callback' in c] 
-        if 'alwaysInvokeEnterCommandOnReturn' in callbacks: 
-            callbacks.remove('alwaysInvokeEnterCommandOnReturn')
-        attribs = list(set(attribs) - set(callbacks))
+        callback_exceptions = { 'alwaysInvokeEnterCommandOnReturn' }
+        callbacks = { c for c in attribs if 'Command' in c or 'Callback' in c }  - callback_exceptions
+        attribs = list(set(attribs) - callbacks)
         quoted = lambda p : "'%s'" % p
         attrib_names = map (quoted, attribs)
         code.write('    _ATTRIBS = [%s]\n' %','.join(attrib_names))


### PR DESCRIPTION
This has two fixes in it:
1) 'alwaysInvokeEnterCommandOnReturn' being flagged as a callback and and not an attribute.
2) TextScrollField.items returning None when empty breaking bindings.