### PR TITLE
Extends the API of ObservableCollection by inheriting from MutableSequence

### DIFF
--- a/mGui/observable.py
+++ b/mGui/observable.py
@@ -3,12 +3,13 @@ Observable.py
 @author: stevetheodore
 """
 import itertools
+from collections import MutableSequence, Sequence
 
 from mGui.bindings import BindableObject
 from mGui.events import MayaEvent, Event
 
 
-class ObservableCollection(BindableObject):
+class ObservableCollection(MutableSequence, BindableObject):
     """
     Encapsulates a collection suitable for data binding. The contents are
     managed internally but visible to other classes as the Contents property
@@ -29,6 +30,7 @@ class ObservableCollection(BindableObject):
 
     Inherits methods from BindableObject, so you can manually trigger an update with update_bindings
     """
+
     _BIND_SRC = 'contents'
     _BIND_TGT = None
 
@@ -43,32 +45,26 @@ class ObservableCollection(BindableObject):
         """
         The contents of the collection.  Bindable.
         """
-        return tuple([i for i in self._internal_collection])
+        return tuple(self)
 
     @property
     def count(self):
         """
         The number of items in the collection. Bindable.
         """
-        return len(self._internal_collection)
+        return len(self)
 
     def add(self, *additions):
         """
         Add items to the collection, with notifications.
         """
-        if len(additions):
-            for each_new in additions:
-                self._internal_collection.append(each_new)
-                self.onItemAdded(each_new, len(self._internal_collection) - 1)
-            self.update_bindings()
-            self.onCollectionChanged(added=True)
+        self.extend(additions)
 
     def add_group(self, *args):
         """
         Add everything in <args>, but only fire the onCollectionChanged event once
         """
-        for item in args:
-            self._internal_collection.append(item)
+        self._internal_collection.extend(args)
         self.update_bindings()
         self.onCollectionChanged(added=True)
 
@@ -81,27 +77,11 @@ class ObservableCollection(BindableObject):
         self.update_bindings()
         self.onCollectionChanged(added=True)
 
-    def remove(self, *delenda):
-        """
-        Removes items from the collection
-        """
-        _found = False
-        for item in delenda:
-            found = self._internal_collection.index(item)
-            if found > -1:
-                self.onItemRemoved(item, found)
-                _found = True
-        for item in delenda:
-            self._internal_collection.remove(item)
-        if _found:  # if this > -1  something was deleted
-            self.update_bindings()
-            self.onCollectionChanged(removed=True)
-
     def clear(self):
         """
         Clear the collection
         """
-        self._internal_collection = []
+        del self._internal_collection[:]
         self.update_bindings()
         self.onCollectionChanged(cleared=True)
 
@@ -114,15 +94,28 @@ class ObservableCollection(BindableObject):
         self.update_bindings()
         self.onCollectionChanged(sorted=True)
 
-    def __iter__(self):
-        """
-        iterates over the contents of the collection
-        """
-        for item in self._internal_collection:
-            yield item
-
     def __getitem__(self, item):
         return self._internal_collection.__getitem__(item)
+
+    def __setitem__(self, index, item):
+        self._internal_collection.__setitem__(index, item)
+        self.onItemAdded(item, index)
+        self.update_bindings()
+        self.onCollectionChanged(added=True)
+
+    def __delitem__(self, index):
+        self.onItemRemoved(self[index], index)
+        self._internal_collection.__delitem__(index)
+        self.update_bindings()
+        self.onCollectionChanged(removed=True)
+
+    def __len__(self):
+        return len(self._internal_collection)
+
+    def reverse(self):
+        self._internal_collection.reverse()
+        self.update_bindings()
+        self.onCollectionChanged(sorted=True)
 
 
 class ImmediateObservableCollection(ObservableCollection):
@@ -146,14 +139,14 @@ class ViewCollection(ObservableCollection):
     _BIND_SRC = 'view'
 
     def __init__(self, *items, **kwargs):
-        self.max_size = kwargs.pop('limit', 0)
-        self.synchronous = kwargs.pop('synchronous', False)
+        self._max_size = kwargs.pop('limit', 0)
+        synchronous = kwargs.pop('synchronous', False)
         super(ViewCollection, self).__init__(*items)
         self.onViewChanged = MayaEvent(collection=self)
-        if self.synchronous:
-            self.onViewChanged = Event(collection = self)
+        if synchronous:
+            self.onViewChanged = Event(collection=self)
 
-        self.filter = lambda p: p
+        self._filter = lambda p: p
         self._last_count = len(self._internal_collection)
         self._truncated = False
 
@@ -163,14 +156,14 @@ class ViewCollection(ObservableCollection):
         Returns a tuple of all the items in this collection which pass the
         current filter. Bindable.
         """
-        filtered = itertools.ifilter(self.filter, self._internal_collection)
+        filtered = itertools.ifilter(self._filter, self._internal_collection)
         result = None
-        if self.max_size > 0:
-            result = tuple(itertools.islice(filtered, self.max_size))
+        if self._max_size > 0:
+            result = tuple(itertools.islice(filtered, self._max_size))
         else:
             result = tuple(filtered)
         self._last_count = len(result)
-        self._truncated = len(result) == self.max_size
+        self._truncated = len(result) == self._max_size
         return result
 
     @property
@@ -182,7 +175,7 @@ class ViewCollection(ObservableCollection):
 
     @property
     def limit(self):
-        return self.max_size
+        return self._max_size
 
     @property
     def is_truncated(self):
@@ -193,9 +186,9 @@ class ViewCollection(ObservableCollection):
         Change the filter expression. This will trigger a ViewChanged event
         """
         if not filter_fn:
-            self.filter = lambda p: p
+            self._filter = lambda p: p
         else:
-            self.filter = filter_fn
+            self._filter = filter_fn
 
         self._last_count = len(self.view)
         self.update_bindings()
@@ -205,14 +198,12 @@ class ViewCollection(ObservableCollection):
         return self.view.__getitem__(item)
 
 
-class BoundCollection(BindableObject):
+class BoundCollection(Sequence, BindableObject):
     """
     An iterable object which can be bound to a collection. When the source
     collection updates, the BoundCollection will fire appropriate update
     callbacks.
 
-    The optional conversion argument is a callable which will be run on every
-    item being forwarded from the source collection.
     """
     _BIND_TGT = 'set_collection'
 
@@ -236,6 +227,12 @@ class BoundCollection(BindableObject):
 
     @property
     def count(self):
+        return len(self)
+
+    def __getitem__(self, item):
+        return self._internal_collection[item]
+
+    def __len__(self):
         return len(self._internal_collection)
 
 

--- a/tests/test_observable_collection.py
+++ b/tests/test_observable_collection.py
@@ -5,7 +5,7 @@ Created on Mar 14, 2014
 '''
 from mGui.bindings import BindableObject, bind
 from mGui.observable import ObservableCollection, ViewCollection, ImmediateObservableCollection
-from unittest import TestCase
+from unittest import TestCase, main
 
 
 class TestTarget(BindableObject):
@@ -56,11 +56,21 @@ class Test_ObservableCollection(TestCase):
 
     def test_base_binding_sort(self):
         t = TestTarget()
+        c = ImmediateObservableCollection(1, 2, 3, 4, 10, 5, 6, 7, 8, 9)
+        t < bind() < c
+        c.update_bindings()
+        c.sort()
+        assert t.values == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        c.sort(reverse=True)
+        assert t.values == (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+    def test_base_binding_reverse(self):
+        t = TestTarget()
         c = ImmediateObservableCollection(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         t < bind() < c
         c.update_bindings()
         assert t.values == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        c.sort(reverse=True)
+        c.reverse()
         assert t.values == (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
     def test_iter(self):
@@ -162,11 +172,21 @@ class TestViewCollection(TestCase):
 
     def test_base_binding_sort(self):
         t = TestTarget()
+        c = ViewCollection(1, 2, 3, 4, 10, 5, 6, 7, 8, 9)
+        t < bind() < c
+        c.update_bindings()
+        c.sort()
+        assert t.values == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        c.sort(reverse=True)
+        assert t.values == (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+    def test_base_binding_reverse(self):
+        t = TestTarget()
         c = ViewCollection(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         t < bind() < c
         c.update_bindings()
         assert t.values == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        c.sort(reverse=True)
+        c.reverse()
         assert t.values == (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
     def test_iter(self):
@@ -183,3 +203,7 @@ class TestViewCollection(TestCase):
         assert t.values == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         c.update_filter(lambda x: x % 2 == 0)
         assert t.values == (2, 4, 6, 8, 10)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This made it a lot easier to teach others how to work with the collections, as they could just reuse what they knew about manipulating lists.

I also went ahead and added a reverse method, which for some reason is not on the MutableSequence abstract class. Though it looks like they fixed this somewhere along the lines for Py3.

The original API was left in place, and all tests continue to pass.

Also extended the API of BoundCollection by inheriting from Sequence, which makes it more tuple-like.