### PR TITLE
Menu loader fix

### DIFF
--- a/mGui/events.py
+++ b/mGui/events.py
@@ -210,7 +210,7 @@ class WeakMethodFree(object):
     def __init__(self, f):
         self.function = weakref.ref(f)
         self.ID = id(f)
-        self._ref_name = f.__name__
+        self._ref_name = getattr(f, '__name__', 'unnamed callable')
 
     def __call__(self, *args, **kwargs):
         if self.function():

--- a/mGui/events.py
+++ b/mGui/events.py
@@ -210,7 +210,7 @@ class WeakMethodFree(object):
     def __init__(self, f):
         self.function = weakref.ref(f)
         self.ID = id(f)
-        self._ref_name = getattr(f, '__name__', 'unnamed callable')
+        self._ref_name = getattr(f, '__name__', "'unnamed'")
 
     def __call__(self, *args, **kwargs):
         if self.function():

--- a/mGui/menu_loader.py
+++ b/mGui/menu_loader.py
@@ -36,6 +36,7 @@ class CallbackProxy(object):
         self.caller = caller
         self.argspec = inspect.getargspec(func)
         self.KEEPALIVE.append(self)
+        self.__name__ = func.__name__
 
     def __call__(self, *args, **kwargs):
         no_kw = self.argspec.keywords is None


### PR DESCRIPTION
Fix for #45.

Added a fallback when acquiring the callable name, this helps handle callables that lack a `__name__` attribute. 
Also added a `__name__` attribute to the `menu_loader.CallbackProxy` object so that it takes advantage of the slightly more descriptive error messages.