### PR TITLE
Adding __all__ to lists.py and gui.py

### DIFF
--- a/mGui/gui.py
+++ b/mGui/gui.py
@@ -59,3 +59,5 @@ def derive(widget):
         result.controls.append(derive(k))
 
     return result
+
+__all__ = [item.__name__ for item in __lookup.values()]

--- a/mGui/lists.py
+++ b/mGui/lists.py
@@ -212,3 +212,5 @@ class ItemTemplate(object):
 
     def __call__(self, item):
         return self.widget(item)
+
+__all__ = ['FormList', 'VerticalList', 'HorizontalList', 'ColumnList', 'WrapList', 'Templated', 'ItemTemplate', ]


### PR DESCRIPTION
Noticed that forms had an an `__all__` attribute but lists and gui did not.
gui's is using the __lookup.values() as it's reference, seemed much simpler than copy and pasting all the strings.

Seemed safer to add these given how many examples are using `import *`