### PR TITLE
Adding a new ModalWindow class.

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -477,17 +477,5 @@ class BindingWindow(Window):
         super(BindingWindow, self).forget()
         self.bindingContext = None
 
-class ModalWindow(BindingWindow):
 
-    def show(self):
-        from maya.OpenMayaUI import MQtUtil
-        from shiboken import wrapInstance
-        from PySide.QtGui import QWidget
-        from PySide import QtCore
-    
-        ptr = MQtUtil.findWindow(self.widget)
-        qt_obj = wrapInstance(long(ptr), QWidget)
-        qt_obj.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
-        qt_obj.show()
-
-__all__ = ['Window', 'BindingWindow', 'ModalWindow', 'Layout', 'Control', 'ControlMeta']
+__all__ = ['Window', 'BindingWindow', 'Layout', 'Control', 'ControlMeta']

--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -476,3 +476,18 @@ class BindingWindow(Window):
     def forget(self, *args, **kwargs):
         super(BindingWindow, self).forget()
         self.bindingContext = None
+
+class ModalWindow(BindingWindow):
+
+    def show(self):
+        from maya.OpenMayaUI import MQtUtil
+        from shiboken import wrapInstance
+        from PySide.QtGui import QWidget
+        from PySide import QtCore
+    
+        ptr = MQtUtil.findWindow(self.widget)
+        qt_obj = wrapInstance(long(ptr), QWidget)
+        qt_obj.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        qt_obj.show()
+
+__all__ = ['Window', 'BindingWindow', 'ModalWindow', 'Layout', 'Control', 'ControlMeta']

--- a/mGui/gui.py
+++ b/mGui/gui.py
@@ -7,7 +7,7 @@ module is probably safe to import * in a known context
 
 import copy
 
-from mGui.core import Window, BindingWindow, ControlMeta
+from mGui.core import *
 from mGui.core.layouts import *
 from mGui.core.menus import *
 from mGui.core.controls import *

--- a/mGui/qt/QTextField.py
+++ b/mGui/qt/QTextField.py
@@ -1,13 +1,20 @@
 __author__ = 'Steve'
+import time
+
 from maya.OpenMayaUI import MQtUtil
-from shiboken import wrapInstance
-from PySide.QtGui import QTextEdit
-from PySide import QtCore
+
+try:
+    from shiboken import wrapInstance
+    from PySide.QtGui import QTextEdit
+    from PySide import QtCore
+except ImportError:
+    from shiboken2 import wrapInstance
+    from PySide2.QtWidgets import QTextEdit
+    from PySide2 import QtCore
 
 from mGui.core.controls import TextField
 from mGui.events import Event
 from mGui.scriptJobs import Idle
-import time
 
 
 def hook_text_changed_event(maya_text_field, event):

--- a/mGui/qt/QWidget.py
+++ b/mGui/qt/QWidget.py
@@ -3,9 +3,14 @@ from ..core import BindingWindow
 
 from maya.OpenMayaUI import MQtUtil
 
-from shiboken import wrapInstance
-from PySide.QtGui import QWidget
-from PySide import QtCore
+try:
+    from shiboken import wrapInstance
+    from PySide.QtGui import QWidget
+    from PySide import QtCore
+except ImportError:
+    from shiboken2 import wrapInstance
+    from PySide2.QtWidgets import QWidget
+    from PySide2 import QtCore
 
 class ModalWindow(BindingWindow):
 

--- a/mGui/qt/QWidget.py
+++ b/mGui/qt/QWidget.py
@@ -1,0 +1,26 @@
+
+from ..core import BindingWindow
+
+from maya.OpenMayaUI import MQtUtil
+
+from shiboken import wrapInstance
+from PySide.QtGui import QWidget
+from PySide import QtCore
+
+class ModalWindow(BindingWindow):
+
+    def __init__(self, *args, **kwargs):
+        super(ModalWindow, self).__init__(*args, **kwargs)
+        ptr = MQtUtil.findWindow(self.widget)
+        self._qt_obj = wrapInstance(long(ptr), QWidget)
+        self._qt_obj.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+
+    def show(self):
+        self._qt_obj.show()
+
+    def forget(self):
+        super(ModalWindow, self).forget()
+        self._qt_obj = None
+
+    def hide(self, *args, **kwargs):
+        self._qt_obj.hide()

--- a/mGui/qt/QWidget.py
+++ b/mGui/qt/QWidget.py
@@ -1,15 +1,16 @@
 
 from ..core import BindingWindow
 
+from maya import cmds
 from maya.OpenMayaUI import MQtUtil
 
 try:
     from shiboken import wrapInstance
-    from PySide.QtGui import QWidget
+    from PySide.QtGui import QWidget, QDialog
     from PySide import QtCore
 except ImportError:
     from shiboken2 import wrapInstance
-    from PySide2.QtWidgets import QWidget
+    from PySide2.QtWidgets import QWidget, QDialog
     from PySide2 import QtCore
 
 class ModalWindow(BindingWindow):
@@ -18,14 +19,23 @@ class ModalWindow(BindingWindow):
         super(ModalWindow, self).__init__(*args, **kwargs)
         ptr = MQtUtil.findWindow(self.widget)
         self._qt_obj = wrapInstance(long(ptr), QWidget)
-        self._qt_obj.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self._qt_obj.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        
 
     def show(self):
         self._qt_obj.show()
 
-    def forget(self):
+    def forget(self, *args, **kwargs):
         super(ModalWindow, self).forget()
         self._qt_obj = None
 
-    def hide(self, *args, **kwargs):
+    def hide(self):
         self._qt_obj.hide()
+
+    def dismiss(self, *args, **kwargs):
+        self.hide()
+        cmds.deleteUI(self)
+
+    def __exit__(self, typ, value, traceback):
+        mGui_expand_stack = True
+        super(ModalWindow, self).__exit__(typ, value, traceback)


### PR DESCRIPTION
Not sure if this fixes #56 or not, but it does provide a potential alternative.
This behaves identically to the BindingWindow, except it blocks input to all other windows.

This allows us to define a ModalWindow, just like any other Window class, and lets us bypass cmds.layoutDialog

For example:
from maya import cmds
from mGui import gui, forms

def test(*_, **__):
    cmds.polySphere()

with gui.ModalWindow() as win:
    with forms.FillForm() as form:
        btn = gui.Button()
        btn.command += test

win.show()
