### PR TITLE
Initial pass at applying a modal context to Controls.

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -122,6 +122,9 @@ class Control(Styled, BindableObject):
         # key is our internal name
         self.key = self.widget.split("|")[-1]
 
+        # Used to track if the control was created in a modal context.
+        self._is_modal = False
+
         # Event objects
         self.callbacks = {}
 
@@ -209,6 +212,7 @@ class Nested(Control):
         self.controls = []
         self.named_children = OrderedDict()
         self.ignore_exceptions = False
+        self._modal_context = False
         super(Nested, self).__init__(key, **kwargs)
 
     def __enter__(self):
@@ -368,6 +372,8 @@ class Nested(Control):
     def add_current(cls, control):
         active = Nested.current()
         if active:
+            if Nested._modal_context:
+                control._is_modal = True
             Nested.ACTIVE_LAYOUT.add(control)
 
     @classmethod

--- a/mGui/forms.py
+++ b/mGui/forms.py
@@ -27,6 +27,7 @@ import itertools
 
 import maya.cmds as cmds
 
+from mGui.core import Nested
 from mGui.core.layouts import FormLayout
 from mGui.styles import Bounds
 
@@ -217,6 +218,15 @@ class LayoutDialogForm(Form):
         self.CMD = self.fake_create
         super(LayoutDialogForm, self).__init__(key=None)
         self.CMD = cmds.formLayout
+
+    def __enter__(self):
+        Nested._modal_context = True
+        return super(LayoutDialogForm, self).__enter__()
+
+    def __exit__(self, typ, value, tb):
+        Nested._modal_context = False
+        return super(LayoutDialogForm, self).__exit__(typ, value, tb)
+
 
     @staticmethod
     def fake_create(*args, **kwargs):

--- a/mGui/properties.py
+++ b/mGui/properties.py
@@ -64,7 +64,10 @@ class CallbackProperty(object):
         # @note: don't use simple truth test here! No-handler event evals to false,
         # so manually assigned events are overwritten!
         if cb is None:
-            obj.callbacks[self.key] = MayaEvent(sender=weakref.proxy(obj))
+            if obj._is_modal:
+                obj.callbacks[self.key] = Event(sender=weakref.proxy(obj))
+            else:
+                obj.callbacks[self.key] = MayaEvent(sender=weakref.proxy(obj))
             obj.register_callback(self.key, obj.callbacks[self.key])
         return obj.callbacks[self.key]
 


### PR DESCRIPTION
First pass on fixing #56.

One thing I noticed when testing this, 
Collections from `mGui.observable` still rely on `MayaEvent`, not sure how big of a concern that is, and unsure on a fix at the moment. Need to dig back into the collection classes.