### PR TITLE
Event handler stash.

### DIFF
--- a/mGui/events.py
+++ b/mGui/events.py
@@ -105,7 +105,7 @@ class Event(object):
             raise ValueError("%s is not callable", handler)
 
         if stash is not None:
-            setattr(stash, '_sh_' + handler.__name__, handler)
+            setattr(stash, '_sh_{}'.format(id(handler)))
 
         self._handlers.add(get_weak_reference(handler))
         return self
@@ -119,7 +119,7 @@ class Event(object):
             handler, stash = handler
 
         try:
-            delattr(stash, '_sh_' + handler.__name__)
+            delattr(stash, '_sh_{}'.format(id(handler)))
         except AttributeError:
             pass
 

--- a/mGui/events.py
+++ b/mGui/events.py
@@ -40,6 +40,22 @@ class Event(object):
         > test = None
         > x()
 
+    a hard reference to a handler can be stored on another object when binding to the event, this can be used
+    for when handlers are defined inside another functions scope. For example:
+        
+        > x = Event()
+        > def test(*args, **kwargs):
+        >   print 'hello world'
+        > class Stash(object):
+        >   pass
+        > stash = Stash()
+        > x += test, stash
+        > del test
+        > x()
+        hello world
+        > del stash
+        > x()
+
     Handlers must exhibit the *args, **kwargs signature.  It's the handler's job
     to decide what to do with them but they will be passed.
 

--- a/mGui/examples/basicList.py
+++ b/mGui/examples/basicList.py
@@ -32,13 +32,9 @@ def basic_list_binding():
         r = random.choice(("pPlane", "pCube", "pSphere")) + str(random.randint(2, 20))
         bound.append(r)
 
-    # these keep the functions above from dropping out of scope
-    test_window.close_window = close_window
-    test_window.more = show_more
-
     # bind the functions to the handlers
-    close.command += test_window.close_window
-    more.command += test_window.more
+    close.command += close_window, test_window
+    more.command += show_more, test_window
 
     return test_window
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -123,6 +123,7 @@ class TestEvents(unittest.TestCase):
         test -= handle
         sample_data.remove("OK")
         test()
+        assert 'OK' not in sample_data
 
     def test_bound_derefencing(self):
         sample_data = []
@@ -138,6 +139,23 @@ class TestEvents(unittest.TestCase):
         assert not "OK" in self.bound_tester.DATA
 
     def test_stash(self):
+        sample_data = []
+
+        def handle(*args, **kwargs):
+            sample_data.append('OK')
+
+        class Stash(object):
+            pass
+        
+        stash = Stash()
+
+        test = events.Event()
+        test += handle, stash
+        del handle
+        test()
+        assert 'OK' in sample_data
+
+    def test_stash_derefencing(self):
         sample_data = []
 
         def handle(*args, **kwargs):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -136,3 +136,28 @@ class TestEvents(unittest.TestCase):
         self.bound_tester.DATA.remove("OK")
         test()
         assert not "OK" in self.bound_tester.DATA
+
+    def test_stash(self):
+        sample_data = []
+
+        def handle(*args, **kwargs):
+            sample_data.append('OK')
+
+        class Stash(object):
+            pass
+        
+        stash = Stash()
+
+        test = events.Event()
+        test += handle, stash
+        del handle
+        test()
+        assert 'OK' in sample_data
+        handle = stash._sh_handle
+        sample_data = []
+        test -= handle, stash
+        test()
+        assert 'OK' not in sample_data
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A possible solution to #40

Instead of trying to infer some kind of stash object like my last solution, this one requires that you explicitly pass a stash object along with the handler.

Updated the example from the issue .
```python
from maya import cmds
from mGui import gui, forms, lists
from mGui.observable import ObservableCollection
from mGui.bindings import bind

def event_test():
    with gui.BindingWindow(title = 'example window') as test_window:
        bound = ObservableCollection("A", "B")

        with forms.VerticalForm() as main:
            gui.Text(label = "The following items don't have vertex colors")
            list_view = lists.VerticalList()
            list_view.bind.collection < bind() < bound
            with forms.HorizontalStretchForm('buttons'):
                refresh = gui.Button('refresh', l='Refresh')
                close = gui.Button('close', l='Close')

    def close_window(*_, **__):
        cmds.deleteUI(test_window)

    def refresh_window(*_, **__):
        list_view.redraw()

    # We pass both the handler, and the object to stash it on
    refresh.command += refresh_window, test_window
    close.command += close_window, test_window
    return test_window

win = event_test()
win.show()
```
Updated the example to use the `+=` syntax, as per the suggestion.