### PR TITLE
Adding a method for preserving callbacks of wrapped controls.

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -161,13 +161,20 @@ class Control(Styled, BindableObject):
         def _spoof_create(*_, **__):
             return control_name
 
-        try:
-            cache_CMD = cls.CMD
-            cls.CMD = _spoof_create
-            return cls(key=control_name)
+        cache_CMD = cls.CMD
+        cls.CMD = _spoof_create
+        wrapped = cls(key=control_name)
+        cls.CMD = cache_CMD
+        wrapped._preserve_callbacks()
+        return wrapped
 
-        finally:
-            cls.CMD = cache_CMD
+
+    def _preserve_callbacks(self, query_cmd=None):
+        query_cmd = query_cmd or self.CMD
+        for cb in self._CALLBACKS:
+            cb_val = query_cmd(self, **{'q': True, cb: True})
+            if cb_val:
+                self.callbacks[cb] = cb_val
 
     @classmethod
     def from_existing(cls, key, widget):

--- a/mGui/core/menus.py
+++ b/mGui/core/menus.py
@@ -25,6 +25,7 @@ class Menu(Nested):
     def itemArray(self):
         return [MenuItem.wrap(self.fullPathName + '|' + item) for item in self.CMD(self.widget, itemArray=True, q=True) or []]
 
+
 class MenuItem(Control):
     CMD = cmds.menuItem
     _ATTRIBS = ["altModifier", "annotation", "allowOptionBoxes", "boldFont", "checkBox", "collection",
@@ -73,7 +74,7 @@ class ActiveOptionMenu(OptionMenu):
 
     """
 
-    def __init__(self, key = None, *args, **kwargs):
+    def __init__(self, key=None, *args, **kwargs):
         super(ActiveOptionMenu, self).__init__(key, *args, **kwargs)
         self.changeCommand += self.fire_menu_callback
 
@@ -96,3 +97,6 @@ class PopupMenu(Nested):
     def itemArray(self):
         return [MenuItem.wrap(self.fullPathName + '|' + item) for item in self.CMD(self.widget, itemArray=True, q=True) or []]
 
+    def _preserve_callbacks(self, query_cmd=None):
+        # popupMenu doesn't let you query the postMenuCommand flag, you have to use menu instead.
+        super(PopupMenu, self)._preserve_callbacks(cmds.menu)


### PR DESCRIPTION
I ran into a few issues using `gui.derive` and `Control.wrap` where I'd lose any callbacks defined on the wrapped widget.

For example:
```python
from mGui import gui
file_menu = gui.derive('mainFileMenu')
print(file_menu.postMenuCommand)
```
Would print an empty `MayaEvent` and overwrite the `postMenuCommand` defined in the mel startup script for the file menu.

With this change, instead we get whatever callback has already been assigned to the control.

