### PR TITLE
Bindable text lists

### DIFF
--- a/mGui/lists.py
+++ b/mGui/lists.py
@@ -17,12 +17,11 @@ too large to display.
 """
 import maya.cmds as cmds
 
-import mGui.forms as forms
-import mGui.observable as observable
 import mGui.core.controls as controls
 import mGui.core.layouts as layouts
 import mGui.events as events
-import time
+import mGui.forms as forms
+import mGui.observable as observable
 
 
 class FormList(object):
@@ -217,4 +216,48 @@ class ItemTemplate(object):
     def __call__(self, item):
         return self.widget(item)
 
-__all__ = ['FormList', 'VerticalList', 'HorizontalList', 'ColumnList', 'WrapList', 'Templated', 'ItemTemplate', ]
+
+class ScrollListBase(FormList):
+    """
+    Base class for  bound scroll lists
+    """
+
+    def redraw(self, *args, **kwargs):
+        self.clear()
+        self.append = [i for i in self.collection]
+
+    def clear(self):
+        self.removeAll = True
+
+    @property
+    def inner_list(self):
+        return self
+
+    def gui_contents(self):
+        yield self
+
+
+class BoundScrollList(controls.TextScrollList, ScrollListBase):
+    """
+    Bindable version of a TextScrollList
+    """
+
+    def __init__(self, key=None, *args, **kwargs):
+        self.__init_bound_collection__(kwargs)
+        super(controls.TextScrollList, self).__init__(key, *args, **kwargs)
+        self.redraw()
+
+
+class BoundIconTextScrollList(controls.IconTextScrollList, ScrollListBase):
+    """
+    Bindable version of a IconTextScrollList
+    """
+
+    def __init__(self, key=None, *args, **kwargs):
+        self.__init_bound_collection__(kwargs)
+        super(controls.IconTextScrollList, self).__init__(key, *args, **kwargs)
+        self.redraw()
+
+
+__all__ = ['FormList', 'VerticalList', 'HorizontalList', 'ColumnList', 'WrapList', 'Templated', 'ItemTemplate',
+           'BoundScrollList', 'BoundIconTextScrollList']


### PR DESCRIPTION
Adds bindable version  of `TextScrollList` and `IconTextScrollList`

```
    from maya import cmds
    from mGui import gui, forms, lists
    from mGui.bindings import bind
    from mGui.observable import ViewCollection
    import re
    
    items = ViewCollection()
    
    def create_filter(*args, **kwargs):
        fn = kwargs['sender'].text
        regex = re.compile(fn, re.I)
        test = lambda p: regex.search(p)
        items.update_filter(test)
    
    
    with gui.Window() as w:
        with forms.FooterForm() as nav:
    
            with forms.HeaderForm() as main:
                filter_field = gui.TextField()
                s = lists.BoundIconTextScrollList()
                
            with forms.HorizontalForm() as footer:
                one = gui.Text(label="Showing: ")
                two = gui.Text(label="0")
                sep = gui.Text(label="/")
                three = gui.Text(label="0")
                
    filter_field.changeCommand += create_filter
    items > bind() > s.collection
    items.bind.viewCount > bind() > three.bind.label
    items.bind.count > bind() > two.bind.label
    w.show()
    items.add(*[i for i in 'abcdefghiklmnopqrstuvwxyz'])
    items.add('hello world')
```