### PR TITLE
Possible method of making Compound Controls

### DIFF
--- a/mGui/core/compound.py
+++ b/mGui/core/compound.py
@@ -1,7 +1,7 @@
 
 import weakref
 
-from .controls import IntField, IconTextButton
+from .controls import IntField, IconTextButton, Button
 from ..forms import HorizontalStretchForm, VerticalStretchForm
 from ..events import MayaEvent
 
@@ -9,14 +9,17 @@ class IntSpinner(IntField):
     
     def __init__(self, key=None, **kwargs):
         self._step = kwargs.pop('step', 1)
-        with HorizontalStretchForm(key='IntSpinner#') as self._root:
-            super(IntSpinner, self).__init__(key, **kwargs)
-            with VerticalStretchForm(width=24):
-                self._up = IconTextButton(height=12, style='iconOnly', image='caret-top')
-                self._down = IconTextButton(height=12, style='iconOnly', image='caret-bottom')
+        height = kwargs.pop('height', kwargs.pop('h', 32))
+        width = kwargs.pop('width', kwargs.pop('w', 256))
+        with HorizontalStretchForm(key='IntSpinner#', height=height, width=width) as self._root:
+            super(IntSpinner, self).__init__(key, height=height, width=width - height, **kwargs)
+            with VerticalStretchForm():
+                self._up = Button(height=height / 2, width=height, label='^') #, style='iconOnly') #, image='caret-top')
+                self._down = Button(height=height / 2, width=height, label='v') #, style='iconOnly') #, image='caret-bottom')
 
         self._up.command += self._inc
         self._down.command += self._dec
+        print(self.height, self.width)
     
 
     @property

--- a/mGui/core/compound.py
+++ b/mGui/core/compound.py
@@ -1,0 +1,34 @@
+
+import weakref
+
+from .controls import IntField, IconTextButton
+from ..forms import HorizontalStretchForm, VerticalStretchForm
+from ..events import MayaEvent
+
+class IntSpinner(IntField):
+    
+    def __init__(self, key=None, **kwargs):
+        self._step = kwargs.pop('step', 1)
+        with HorizontalStretchForm(key='IntSpinner#') as self._root:
+            super(IntSpinner, self).__init__(key, **kwargs)
+            with VerticalStretchForm(width=24):
+                self._up = IconTextButton(height=12, style='iconOnly', image='caret-top')
+                self._down = IconTextButton(height=12, style='iconOnly', image='caret-bottom')
+
+        self._up.command += self._inc
+        self._down.command += self._dec
+    
+
+    @property
+    def step(self):
+        return self._step
+
+    @step.setter
+    def step(self, value):
+        self._step = value
+
+    def _inc(self, *args, **kwargs):
+        self.value += self._step
+
+    def _dec(self, *args, **kwargs):
+        self.value -= self._step

--- a/mGui/core/compound.py
+++ b/mGui/core/compound.py
@@ -6,6 +6,35 @@ from ..forms import HorizontalStretchForm, VerticalStretchForm
 from ..events import MayaEvent
 
 
+class CompoundControl(type):
+    # Some magic will happen here?
+    pass
+
+
+class IntSpinner:
+    __metaclass__ = CompoundControl
+
+    _CONTROLS = {
+        'root': HorizontalStretchForm,
+        'field': IntField,
+        'label': Text,
+        'decrement': Button,
+        'increment': Button,
+        'form': VerticalStretchForm,
+    }
+    _HIERARCHY = {
+        'root': (
+            'label',
+            'field', {
+                'form': (
+                    'increment',
+                    'decrement'
+                )
+            }
+        )
+    }
+
+
 class IntSpinner(object):
 
     def __init__(self, key=None, **kwargs):

--- a/mGui/core/compound.py
+++ b/mGui/core/compound.py
@@ -1,26 +1,27 @@
 
 import weakref
 
-from .controls import IntField, IconTextButton, Button
+from .controls import IntField, IconTextButton, Button, Text
 from ..forms import HorizontalStretchForm, VerticalStretchForm
 from ..events import MayaEvent
 
-class IntSpinner(IntField):
-    
+
+class IntSpinner(object):
+
     def __init__(self, key=None, **kwargs):
         self._step = kwargs.pop('step', 1)
+        value = kwargs.pop('value', 0)
+
         height = kwargs.pop('height', kwargs.pop('h', 32))
         width = kwargs.pop('width', kwargs.pop('w', 256))
-        with HorizontalStretchForm(key='IntSpinner#', height=height, width=width) as self._root:
-            super(IntSpinner, self).__init__(key, height=height, width=width - height, **kwargs)
-            with VerticalStretchForm():
-                self._up = Button(height=height / 2, width=height, label='^') #, style='iconOnly') #, image='caret-top')
-                self._down = Button(height=height / 2, width=height, label='v') #, style='iconOnly') #, image='caret-bottom')
+        with HorizontalStretchForm(key='IntSpinner#', **kwargs) as self.root:
+            self.field = IntField(height=height, width=width - height, value=value)
+            with VerticalStretchForm() as self.form:
+                self.increment = Button(height=height / 2, width=height, label='^')
+                self.decrement = Button(height=height / 2, width=height, label='v')
 
-        self._up.command += self._inc
-        self._down.command += self._dec
-        print(self.height, self.width)
-    
+        self.increment.command += self._inc
+        self.decrement.command += self._dec
 
     @property
     def step(self):
@@ -31,7 +32,18 @@ class IntSpinner(IntField):
         self._step = value
 
     def _inc(self, *args, **kwargs):
-        self.value += self._step
+        self.field.value += self._step
 
     def _dec(self, *args, **kwargs):
-        self.value -= self._step
+        self.field.value -= self._step
+
+    def __getattr__(self, attr):
+        if hasattr(self, 'root') and hasattr(self.root, attr):
+            return getattr(self.root, attr)
+        return super(IntSpinner, self).__getattribute__(attr)
+
+    def __setattr__(self, attr, value):
+        if hasattr(self, 'root') and hasattr(self.root, attr):
+            setattr(self.root, attr, value)
+        else:
+            self.__dict__[attr] = value


### PR DESCRIPTION
Initial example is an IntSpinner.
Based on the conversation over at [TAO](http://tech-artists.org/t/maya-python-spinbox-using-maya-cmds/8952/17?u=r.white)

Basically just expands the `IntField` with a new `step` value, and links the two buttons to increment and decrement the value.

```python
from mGui import gui, forms, core
from mGui.core.compound import IntSpinner

with gui.Window() as win:
    with forms.VerticalForm() as main:
        spinner = IntSpinner(width=256, height=24)
        gui.Separator()
        spinner2 = IntSpinner(width=256, height=24, step=5)

win.show()
```

If we want to further expose the button commands, we'd need some kind of descriptor to route the `Events` from the sub commands, but that should be fairly simple.
