### PR TITLE
replaced generator expression with list

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -347,7 +347,7 @@ class Nested(Control):
                 self.named_children.pop(key)
 
     def clear(self):
-        delenda = (i for i in self.controls)
+        delenda = self.controls[:]
         for d in delenda:
             self.remove(d)
         self.named_children.clear()


### PR DESCRIPTION
The generator expression was causing Nested.clear to not actually iterate over all the controls.

I submitted issue #90 describing the problem.