### PR TITLE
Reverted part of the last change

### DIFF
--- a/mGui/shelf_loader.py
+++ b/mGui/shelf_loader.py
@@ -124,7 +124,7 @@ class MenuItemProxy(BaseLoader):
     sourceType = ''
 
     def instantiate(self, parent=None):
-        popup = self.proxy.wrap(parent.fullPathName + "|" + parent.popupMenuArray[0])
+        popup = gui.PopupMenu.wrap(parent.fullPathName + "|" + parent.popupMenuArray[0])
         for item in popup.itemArray:
             item = self.proxy.wrap(popup.fullPathName + "|" + item)
             # widget gets recreated by Maya, but the key is used as the label.


### PR DESCRIPTION
Line 127: self.proxy.wrap is returning a gui.MenuItem, which breaks on the following line because MenuItem doesn't have an itemArray attribute.  Reverted this line to gui.PopupMenu, since that seems to work.