### PR TITLE
Shelf loader improvements.

### DIFF
--- a/mGui/core/__init__.py
+++ b/mGui/core/__init__.py
@@ -384,7 +384,7 @@ class Nested(Control):
         """
         return [i for i in self.controls if isinstance(i, mGuiType)]
 
-    # note: both of these explicitly use Nested instead of clsm
+    # note: both of these explicitly use Nested instead of cls
     # so that there is only one global layout stack...
 
     @classmethod

--- a/mGui/examples/shelf_example.py
+++ b/mGui/examples/shelf_example.py
@@ -1,8 +1,32 @@
 import os
 import json
-from mGui import shelf_loader
+import urllib2
+
+from mGui import shelf_loader, core, gui, forms
+
+url = 'https://raw.githubusercontent.com/theodox/mGui/master/mGui/examples/shelf_example.json'
+
+example_file = os.path.join(os.path.dirname(__file__), 'shelf_example.json')
+shelf_dict = json.load(open(example_file))
+
+def add_to_main_shelf_layout():
+    shelf_loader.load_shelf(shelf_dict)
+
+
+def create_floating_shelf():
+    if core.MAYA_VERSION >= '2017':
+        with gui.WorkspaceControl() as win:
+            with forms.FillForm() as f:
+                with gui.ShelfTabLayout() as shelf:
+                   shelf_loader.load_shelf(shelf_dict, shelf)
+
+def load_shelf_from_url():
+    shelf_dict = json.load(urllib2.urlopen(url))
+    shelf_loader.load_shelf(shelf_dict)
+
 
 if __name__ == '__main__':
-    example_file = os.path.join(os.path.dirname(__file__), 'shelf_example.json')
-    shelf_loader.load_shelf(json.load(open(example_file)))
-    
+
+    # add_to_main_shelf_layout()
+    # create_floating_shelf()
+    load_shelf_from_url()

--- a/mGui/shelf_loader.py
+++ b/mGui/shelf_loader.py
@@ -36,11 +36,12 @@ class ShelfLayoutProxy(BaseLoader):
             parent = gui.wrap(self.parent)
 
         # initializes all the shelves
-        current_tab = parent.selectTab
-        for child in parent.childArray:
-            parent.selectTab = child
+        if parent.selectTab:
+            current_tab = parent.selectTab
+            for child in parent.childArray:
+                parent.selectTab = child
 
-        parent.selectTab = current_tab
+            parent.selectTab = current_tab
 
         for shelf in parent.controls:
             if shelf.key == self.key:
@@ -48,11 +49,13 @@ class ShelfLayoutProxy(BaseLoader):
         else:
             with parent.as_parent():
                 shelf = self.proxy(self.key)
+    
                 # Needed so that we don't throw a weird maya error until the next restart.
                 # Pulled this from the shelf editor mel script.
-                cmds.optionVar(stringValue=('shelfName{}'.format(parent.numberOfChildren), self.key))
-                cmds.optionVar(intValue=('shelfLoad{}'.format(parent.numberOfChildren), True))
-                cmds.optionVar(stringValue=('shelfFile{}'.format(parent.numberOfChildren), ''))
+                if parent == 'ShelfLayout':
+                    cmds.optionVar(stringValue=('shelfName{}'.format(parent.numberOfChildren), self.key))
+                    cmds.optionVar(intValue=('shelfLoad{}'.format(parent.numberOfChildren), True))
+                    cmds.optionVar(stringValue=('shelfFile{}'.format(parent.numberOfChildren), ''))
 
         for ctrl in self.controls:
             ctrl.instantiate(shelf)
@@ -152,6 +155,6 @@ class MenuItemProxy(BaseLoader):
             item.command = _process_command(self.command)
 
 
-def load_shelf(shelf_dict):
+def load_shelf(shelf_dict, parent=None):
     shelf = ShelfLayoutProxy(shelf_dict)
-    shelf.instantiate()
+    shelf.instantiate(parent)


### PR DESCRIPTION
Fixes some bugs with loading shelves when the parent isn't the main shelf layout.
Updated the examples to pull from the github URL of the json file to demonstrate loading the shelves remotely.
Also added an example that loads the example shelf into a floating dockable shelf layout.